### PR TITLE
Add allowInline option to NoCallbacksInFunction

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ HbmartinRuleSet:
     ignoreAnnotated: ['Composable']
     allowExtensions: true
     allowReceivers: true
+    allowInline: false
   NoNotNullOperator:
     active: true
   NoVarsInConstructor:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.21"
+    kotlin("jvm") version "2.0.0"
     `maven-publish`
     alias(libs.plugins.detekt)
     jacoco

--- a/src/main/kotlin/me/haroldmartin/detektrules/NoCallbacksInFunctions.kt
+++ b/src/main/kotlin/me/haroldmartin/detektrules/NoCallbacksInFunctions.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.rules.isInline
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
@@ -27,9 +28,13 @@ class NoCallbacksInFunctions(config: Config) : Rule(config) {
     @Suppress("BooleanPropertyNaming")
     private val allowExtensions: Boolean by config(true)
 
+    @Suppress("BooleanPropertyNaming")
+    private val allowInline: Boolean by config(false)
+
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
         if (allowExtensions && function.isExtensionDeclaration()) return
+        if (allowInline && function.isInline()) return
         function
             .functionTypeParameters
             ?.mapNotNull { paramText ->

--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -21,6 +21,7 @@ HbmartinRuleSet:
     ignoreAnnotated: ['Composable']
     allowExtensions: true
     allowReceivers: true
+    allowInline: false
 
   WhenBranchSingleLineOrBraces:
     active: true

--- a/src/test/kotlin/me/haroldmartin/detektrules/NoCallbacksInFunctionsTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/NoCallbacksInFunctionsTest.kt
@@ -95,6 +95,26 @@ fun mydsl(function: String.() -> Unit) {
         val findings = NoCallbacksInFunctions(KeyedConfig("allowReceivers", false)).compileAndLintWithContext(env, code)
         findings shouldHaveSize 1
     }
+
+    @Test
+    fun `does report inline function if not allowed`() {
+        val code = """
+inline fun myinline(function: () -> Unit) {
+}
+        """
+        val findings = NoCallbacksInFunctions(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `does not report inline function if allowed`() {
+        val code = """
+inline fun myinline(function: () -> Unit) {
+}
+        """
+        val findings = NoCallbacksInFunctions(KeyedConfig("allowInline", true)).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
 }
 
 internal class KeyedConfig(private val key: String, private val value: Boolean) : Config {


### PR DESCRIPTION


<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce 'allowInline' option to the NoCallbacksInFunctions rule, update the rule to respect this configuration, and add corresponding tests. Upgrade Kotlin version to 2.0.0 and update GitHub Actions workflow to use actions/checkout@v4. Document the new option in the README.

New Features:
- Introduce 'allowInline' option to the NoCallbacksInFunctions rule to control whether inline functions are reported.

Enhancements:
- Update NoCallbacksInFunctions rule to respect the new 'allowInline' configuration.

Build:
- Upgrade Kotlin version to 2.0.0 in build.gradle.kts.

CI:
- Update GitHub Actions workflow to use actions/checkout@v4.

Documentation:
- Add documentation for the 'allowInline' option in the README.md.

Tests:
- Add tests to verify the behavior of the NoCallbacksInFunctions rule with the 'allowInline' option enabled and disabled.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option `allowInline` in the `HbmartinRuleSet` to prohibit inline annotations.
  - Enhanced `NoCallbacksInFunctions` rule to allow configuration for inline functions.

- **Bug Fixes**
  - Updated the version of the `actions/checkout` action for improved workflow reliability.

- **Tests**
  - Added new test cases to validate behavior related to inline functions in the `NoCallbacksInFunctions` rule.

- **Documentation**
  - Updated README to reflect changes in the `HbmartinRuleSet` configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->