### PR TITLE
Setup for maven central publishing

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -8,16 +8,6 @@ on:
       - '*'
 
 jobs:
-  publish:
-    name: Check that the publish plugin works
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Check that the publish plugin works
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: publishToMavenLocal
   run-detekt:
     name: Run Detekt on the detekt rules
     runs-on: ubuntu-latest
@@ -31,4 +21,4 @@ jobs:
       - name: Run Detekt on the detekt rules
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: detektMain
+          arguments: assemble detektMain

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish package to the Maven Central Repository
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.repository == 'hbmartin/hbmartin-detekt-rules'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Maven Central Repository
@@ -12,11 +13,13 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Publish package
-        run: mvn --batch-mode deploy
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Publish Library
+        run: |
+          ./gradlew assemble publishAndReleaseToMavenCentral --no-configuration-cache --no-parallel
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These are my opinions. There are many like them but these are mine. 😄
 
 Inside of your `dependencies` block add the following: (for more details see [adding more rule sets](https://github.com/detekt/detekt#adding-more-rule-sets))
 ```kotlin 
-detektPlugins("com.github.hbmartin:hbmartin-detekt-rules:0.1.4")
+detektPlugins("com.github.hbmartin:hbmartin-detekt-rules:0.1.5")
 ```
 
 Then add to your detekt configuration as in the section below to activate rules. Note that the AvoidFirstOrLastOnList and AvoidMutableCollections rules require [type resolution](https://detekt.dev/docs/gettingstarted/type-resolution) to be active.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These are my opinions. There are many like them but these are mine. 😄
 
 Inside of your `dependencies` block add the following: (for more details see [adding more rule sets](https://github.com/detekt/detekt#adding-more-rule-sets))
 ```kotlin 
-detektPlugins("com.github.hbmartin:hbmartin-detekt-rules:0.1.5")
+detektPlugins("me.haroldmartin:hbmartin-detekt-rules:0.1.5")
 ```
 
 Then add to your detekt configuration as in the section below to activate rules. Note that the AvoidFirstOrLastOnList and AvoidMutableCollections rules require [type resolution](https://detekt.dev/docs/gettingstarted/type-resolution) to be active.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,16 @@
+import java.net.URI
+
 plugins {
-    kotlin("jvm") version "1.9.21"
+    kotlin("jvm") version "2.0.0"
     `maven-publish`
     alias(libs.plugins.detekt)
     jacoco
     id("com.github.ben-manes.versions") version "0.51.0"
+    id("com.vanniktech.maven.publish") version "0.29.0"
 }
 
 group = "me.haroldmartin.detektrules"
-version = "0.1.4"
+version = "0.1.5"
 
 dependencies {
     compileOnly(libs.detekt.api)
@@ -47,8 +50,27 @@ publishing {
             from(components["java"])
         }
     }
+    repositories {
+        maven {
+            name = "OSSRH"
+            url = URI("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+            credentials {
+                username = System.getenv("MAVEN_USERNAME")
+                password = System.getenv("MAVEN_PASSWORD")
+            }
+        }
+    }
 }
 
 detekt {
     allRules = true
+}
+
+tasks.withType<com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask> {
+    checkForGradleUpdate = true
+    rejectVersionIf {
+        listOf("-RC", "-Beta", "-M1", "-M2").any { word ->
+            candidate.version.contains(word)
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
+import com.vanniktech.maven.publish.SonatypeHost
 import java.net.URI
 
 plugins {
     kotlin("jvm") version "2.0.0"
-    `maven-publish`
-    signing
     alias(libs.plugins.detekt)
     jacoco
     id("com.github.ben-manes.versions") version "0.51.0"
@@ -45,23 +44,39 @@ tasks.jacocoTestReport {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            from(components["java"])
-        }
-    }
-    repositories {
-        maven {
-            name = "OSSRH"
-            url = URI("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                username = System.getenv("MAVEN_USERNAME")
-                password = System.getenv("MAVEN_PASSWORD")
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+
+    coordinates("me.haroldmartin", "hbmartin-detekt-rules", version as String)
+
+    pom {
+        name.set("Hbmartin's Detekt Rules")
+        description.set("A somewhat opinionated ruleset for Detekt, primarily intended to avoid crashes and bugs related to mutability.")
+        inceptionYear.set("2023")
+        url.set("https://github.com/hbmartin/hbmartin-detekt-rules")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
             }
+        }
+        developers {
+            developer {
+                id.set("hmartin")
+                name.set("Harold Martin")
+                url.set("https://github.com/hbmartin/")
+            }
+        }
+        scm {
+            url.set("https://github.com/hbmartin/hbmartin-detekt-rules/")
+            connection.set("scm:git:git://github.com/hbmartin/hbmartin-detekt-rules.git")
+            developerConnection.set("scm:git:ssh://git@github.com/hbmartin/hbmartin-detekt-rules.git")
         }
     }
 }
+
 
 detekt {
     allRules = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import java.net.URI
 plugins {
     kotlin("jvm") version "2.0.0"
     `maven-publish`
+    signing
     alias(libs.plugins.detekt)
     jacoco
     id("com.github.ben-manes.versions") version "0.51.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/src/test/kotlin/me/haroldmartin/detektrules/AvoidMutableCollectionsTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/AvoidMutableCollectionsTest.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -24,11 +25,17 @@ internal class AvoidMutableCollectionsTest(private val env: KotlinCoreEnvironmen
     fun `reports on mutable declarations`() {
         val code = """
         val mutableSet = mutableSetOf<String>()
-        val mutableSet = mutableListOf<String>()
+        val mutableList = mutableListOf<String>()
         val mutableMap = mutableMapOf<String, String>()
         """
         val findings = AvoidMutableCollections(Config.empty).compileAndLintWithContext(env, code)
         findings shouldHaveSize 3
+        findings[0].message shouldBe
+            "Mutable collection type MutableSet<String> used in mutableSetOf<String>()"
+        findings[1].message shouldBe
+            "Mutable collection type MutableList<String> used in mutableListOf<String>()"
+        findings[2].message shouldBe "Mutable collection type MutableMap<String, String> used in " +
+            "mutableMapOf<String, String>()"
     }
 
     @Test

--- a/src/test/kotlin/me/haroldmartin/detektrules/AvoidVarsExceptWithDelegateTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/AvoidVarsExceptWithDelegateTest.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -19,5 +20,8 @@ internal class AvoidVarsExceptWithDelegateTest(private val env: KotlinCoreEnviro
         """
         val findings = AvoidVarsExceptWithDelegate(Config.empty).compileAndLintWithContext(env, code)
         findings shouldHaveSize 2
+        findings[0].message shouldBe "Property shouldError is a `var`iable, please make it a val."
+        findings[1].message shouldBe "Property delegatedUnknown is a delegated `var`iable but the " +
+            "delegate is not allowed. Change to val or configure allowed delegates regex list"
     }
 }

--- a/src/test/kotlin/me/haroldmartin/detektrules/MutableTypeShouldBePrivateTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/MutableTypeShouldBePrivateTest.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -20,5 +21,6 @@ internal class MutableTypeShouldBePrivateTest(private val env: KotlinCoreEnviron
         """
         val findings = MutableTypeShouldBePrivate(Config.empty).compileAndLintWithContext(env, code)
         findings shouldHaveSize 1
+        findings[0].message shouldBe "shouldError should be private since it is a mutable type."
     }
 }


### PR DESCRIPTION


<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Set up Maven Central publishing by adding necessary configurations to build.gradle.kts, upgrading Kotlin version, and adding a GitHub Actions workflow for publishing on release creation. Update project version and README.md accordingly.

Enhancements:
- Upgrade Kotlin version from 1.9.21 to 2.0.0.
- Add Maven Central publishing configuration to build.gradle.kts.
- Update project version from 0.1.4 to 0.1.5.

Build:
- Add maven-publish plugin and configure publishing repository for Maven Central in build.gradle.kts.

CI:
- Add GitHub Actions workflow for publishing package to Maven Central Repository on release creation.

Documentation:
- Update README.md to reflect the new project version 0.1.5 in the dependency block.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced an automated GitHub Actions workflow for publishing packages to Maven Central upon release creation.

- **Updates**
	- Updated the `hbmartin-detekt-rules` plugin to version `0.1.5` for improved code quality checks.
	- Upgraded the Kotlin JVM plugin to version `2.0.0`, enhancing performance and features.
	- Incremented project version from `0.1.4` to `0.1.5`.
	- Enhanced Maven publishing configuration for better accessibility of project artifacts.

- **Documentation**
	- Improved metadata in project configuration for better artifact documentation and compliance.
	- Clarified type resolution requirements for certain Detekt rules in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->