### PR TITLE
Precomputing the normalized names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ outTmp/
 kotlin-ide/
 .kotlin/
 .teamcity/reviews_triage/
+reviews_triage/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,6 @@ version = "0.1.7"
 
 dependencies {
     compileOnly(libs.detekt.api)
-    implementation("org.jetbrains.kotlin:kotlin-stdlib") {
-        version { strictly("2.0.21") }
-    }
 
     testImplementation(libs.detekt.test)
     testImplementation(libs.kotest.assertions.core)

--- a/src/main/kotlin/me/haroldmartin/detektrules/AvoidMutableCollections.kt
+++ b/src/main/kotlin/me/haroldmartin/detektrules/AvoidMutableCollections.kt
@@ -118,9 +118,9 @@ private fun KtExpression.isInsideCollectionBuilder(bindingContext: BindingContex
     .filterIsInstance<KtCallExpression>()
     .mapNotNull { it.calleeExpression as? KtNameReferenceExpression }
     .any { callee ->
-        bindingContext[BindingContext.REFERENCE_TARGET, callee]
-            ?.fqNameSafe
-            ?.asString() in BUILDER_FUNCTION_FQ_NAMES
+        bindingContext[BindingContext.REFERENCE_TARGET, callee]?.run {
+            fqNameSafe.asString() in BUILDER_FUNCTION_FQ_NAMES
+        } == true
     }
 
 private fun PsiElement.isInPrivateOrLocalScope(): Boolean =

--- a/src/main/kotlin/me/haroldmartin/detektrules/NoDeferredResultInPublicApi.kt
+++ b/src/main/kotlin/me/haroldmartin/detektrules/NoDeferredResultInPublicApi.kt
@@ -77,7 +77,7 @@ private fun KtProperty.isReportableDeclaration(): Boolean =
 
 private fun KtTypeReference.isDeferredType(bindingContext: BindingContext): Boolean =
     bindingContext[BindingContext.TYPE, this]
-        ?.constructor
-        ?.declarationDescriptor
-        ?.fqNameSafe
-        ?.asString() == "kotlinx.coroutines.Deferred"
+        ?.run { constructor.declarationDescriptor }
+        ?.run {
+            fqNameSafe.asString()
+        } == "kotlinx.coroutines.Deferred"

--- a/src/main/kotlin/me/haroldmartin/detektrules/NoLateinitVar.kt
+++ b/src/main/kotlin/me/haroldmartin/detektrules/NoLateinitVar.kt
@@ -38,6 +38,8 @@ class NoLateinitVar(config: Config) : Rule(config) {
 
     @Configuration("annotations that permit a lateinit var, e.g. ['Inject']")
     private val allowedAnnotations: List<String> by config(emptyList<String>())
+    private val allowedAnnotationShortNames: Set<String> =
+        allowedAnnotations.mapTo(mutableSetOf()) { it.substringAfterLast('.') }
 
     override fun visitProperty(property: KtProperty) {
         super.visitProperty(property)
@@ -53,9 +55,6 @@ class NoLateinitVar(config: Config) : Rule(config) {
         }
     }
 
-    private fun KtProperty.hasAllowedAnnotation(): Boolean = annotationEntries.any { entry ->
-        entry.shortName?.asString()?.let { shortName ->
-            allowedAnnotations.any { it.substringAfterLast('.') == shortName }
-        } == true
-    }
+    private fun KtProperty.hasAllowedAnnotation(): Boolean =
+        annotationEntries.any { it.shortName?.asString() in allowedAnnotationShortNames }
 }


### PR DESCRIPTION
Fixed all three ReplaceSafeCallChainWithRun findings Removed the explicit strict stdlib declaration (Gradle module metadata uses "requires": "2.0.21", with no strictly)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/hbmartin-detekt-rules/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

