### PR TITLE
Replaced mutableSetOf() accumulation with immutable map(...).toSet() …

### DIFF
--- a/src/main/kotlin/me/haroldmartin/detektrules/NoDeferredResultInPublicApi.kt
+++ b/src/main/kotlin/me/haroldmartin/detektrules/NoDeferredResultInPublicApi.kt
@@ -75,7 +75,9 @@ private fun KtNamedFunction.isReportableDeclaration(): Boolean =
 private fun KtProperty.isReportableDeclaration(): Boolean =
     isPublic && !isLocal && !hasModifier(KtTokens.OVERRIDE_KEYWORD)
 
-private fun KtTypeReference.isDeferredType(bindingContext: BindingContext): Boolean =
-    bindingContext[BindingContext.TYPE, this]?.run {
-        constructor.declarationDescriptor?.fqNameSafe?.asString()
-    } == "kotlinx.coroutines.Deferred"
+private fun KtTypeReference.isDeferredType(bindingContext: BindingContext): Boolean {
+    val descriptor = bindingContext[BindingContext.TYPE, this]?.run {
+        constructor.declarationDescriptor
+    } ?: return false
+    return descriptor.fqNameSafe.asString() == "kotlinx.coroutines.Deferred"
+}

--- a/src/main/kotlin/me/haroldmartin/detektrules/NoLateinitVar.kt
+++ b/src/main/kotlin/me/haroldmartin/detektrules/NoLateinitVar.kt
@@ -39,7 +39,7 @@ class NoLateinitVar(config: Config) : Rule(config) {
     @Configuration("annotations that permit a lateinit var, e.g. ['Inject']")
     private val allowedAnnotations: List<String> by config(emptyList<String>())
     private val allowedAnnotationShortNames: Set<String> =
-        allowedAnnotations.mapTo(mutableSetOf()) { it.substringAfterLast('.') }
+        allowedAnnotations.map { it.substringAfterLast('.') }.toSet()
 
     override fun visitProperty(property: KtProperty) {
         super.visitProperty(property)

--- a/src/test/kotlin/me/haroldmartin/detektrules/AvoidFirstOrLastOnListTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/AvoidFirstOrLastOnListTest.kt
@@ -219,4 +219,15 @@ internal class AvoidFirstOrLastOnListTest(private val env: KotlinCoreEnvironment
         val findings = AvoidFirstOrLastOnList(Config.empty).compileAndLintWithContext(env, code)
         findings shouldHaveSize 0
     }
+
+    @Test
+    fun `does not report qualified property access or receiverless callable reference`() {
+        val code = """
+        fun first(): String = "first"
+        val shouldNotError = listOf("hi").size
+        val shouldNotErrorEither = ::first
+        """
+        val findings = AvoidFirstOrLastOnList(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
 }

--- a/src/test/kotlin/me/haroldmartin/detektrules/AvoidMutableCollectionsTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/AvoidMutableCollectionsTest.kt
@@ -252,12 +252,4 @@ internal class AvoidMutableCollectionsTest(private val env: KotlinCoreEnvironmen
         findings shouldHaveSize 2
     }
 
-    @Test
-    fun `does not report concrete Java collection type`() {
-        val code = """
-        val values = ArrayList<Int>()
-        """
-        val findings = AvoidMutableCollections(Config.empty).compileAndLintWithContext(env, code)
-        findings shouldHaveSize 0
-    }
 }

--- a/src/test/kotlin/me/haroldmartin/detektrules/AvoidMutableCollectionsTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/AvoidMutableCollectionsTest.kt
@@ -213,4 +213,51 @@ internal class AvoidMutableCollectionsTest(private val env: KotlinCoreEnvironmen
         val findings = AvoidMutableCollections(config).compileAndLintWithContext(env, code)
         findings shouldHaveSize 1
     }
+
+    @Test
+    fun `reports inferred public mutable collections when private and local are allowed`() {
+        val code = """
+        val mutableSet = mutableSetOf<String>()
+        """
+        val config = TestConfig("allowPrivateAndLocal" to "true")
+        val findings = AvoidMutableCollections(config).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `reports mutable initializer exposed as an immutable type`() {
+        val code = """
+        val values: Collection<Int> = mutableListOf()
+        """
+        val findings = AvoidMutableCollections(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `reports mutable collection in a constructor argument`() {
+        val code = """
+        open class Base(val values: List<Int>)
+        class Child : Base(mutableListOf())
+        """
+        val findings = AvoidMutableCollections(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `reports mutable collection returned through an invoked lambda`() {
+        val code = """
+        val values = ({ mutableListOf(1) })()
+        """
+        val findings = AvoidMutableCollections(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 2
+    }
+
+    @Test
+    fun `does not report concrete Java collection type`() {
+        val code = """
+        val values = ArrayList<Int>()
+        """
+        val findings = AvoidMutableCollections(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
 }

--- a/src/test/kotlin/me/haroldmartin/detektrules/AvoidToIntOrThrowingConversionsTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/AvoidToIntOrThrowingConversionsTest.kt
@@ -63,4 +63,13 @@ internal class AvoidToIntOrThrowingConversionsTest(private val env: KotlinCoreEn
         findings[0].message shouldContain "toIntOrNull(...)"
         findings[0].message shouldContain "toInt(...)"
     }
+
+    @Test
+    fun `does not report qualified property access`() {
+        val code = """
+        val shouldNotError = "five".length
+        """
+        val findings = AvoidToIntOrThrowingConversions(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
 }

--- a/src/test/kotlin/me/haroldmartin/detektrules/AvoidVarsExceptWithDelegateTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/AvoidVarsExceptWithDelegateTest.kt
@@ -37,6 +37,22 @@ internal class AvoidVarsExceptWithDelegateTest(private val env: KotlinCoreEnviro
         ).compileAndLintWithContext(env, code)
         findings shouldHaveSize 0
     }
+
+    @Test
+    fun `reports delegated var when delegate expression has no name`() {
+        val code = """
+        import kotlin.reflect.KProperty
+
+        operator fun Int.getValue(thisRef: Any?, property: KProperty<*>): Int = this
+        operator fun Int.setValue(thisRef: Any?, property: KProperty<*>, value: Int) = Unit
+
+        var delegated by 1
+        """
+        val findings = AvoidVarsExceptWithDelegate(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+        findings[0].message shouldBe "Property delegated is a delegated `var`iable but the delegate is " +
+            "not allowed. Change to val or configure allowed delegates regex list"
+    }
 }
 
 // Compilable stand-ins for Compose-style delegate providers used in the snippets above.

--- a/src/test/kotlin/me/haroldmartin/detektrules/MutableTypeShouldBePrivateTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/MutableTypeShouldBePrivateTest.kt
@@ -62,4 +62,14 @@ internal class MutableTypeShouldBePrivateTest(private val env: KotlinCoreEnviron
         findings shouldHaveSize 1
         findings[0].message shouldBe "reported should be private since it is a mutable type."
     }
+
+    @Test
+    fun `does not report a property whose type cannot be guessed syntactically`() {
+        val code = """
+        val calculated
+            get() = "value"
+        """
+        val findings = MutableTypeShouldBePrivate(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
 }

--- a/src/test/kotlin/me/haroldmartin/detektrules/NoCallbacksInFunctionsTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/NoCallbacksInFunctionsTest.kt
@@ -115,6 +115,17 @@ inline fun myinline(function: () -> Unit) {
         val findings = NoCallbacksInFunctions(KeyedConfig("allowInline", true)).compileAndLintWithContext(env, code)
         findings shouldHaveSize 0
     }
+
+    @Test
+    fun `reports non inline callback when only inline callbacks are allowed`() {
+        val code = """
+        fun notInline(function: () -> Unit) {
+            function()
+        }
+        """
+        val findings = NoCallbacksInFunctions(KeyedConfig("allowInline", true)).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
 }
 
 internal class KeyedConfig<X : Any>(private val key: String, private val value: X) : Config {

--- a/src/test/kotlin/me/haroldmartin/detektrules/NoDeferredResultInPublicApiTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/NoDeferredResultInPublicApiTest.kt
@@ -102,4 +102,27 @@ internal class NoDeferredResultInPublicApiTest(private val env: KotlinCoreEnviro
         val findings = NoDeferredResultInPublicApi(Config.empty).compileAndLintWithContext(env, code)
         findings shouldHaveSize 2
     }
+
+    @Test
+    fun `does not report inferred non Deferred or local function results`() {
+        val code = """
+        import kotlinx.coroutines.CoroutineScope
+        import kotlinx.coroutines.Deferred
+        import kotlinx.coroutines.async
+
+        class Repository(private val scope: CoroutineScope) {
+            fun inferredDeferred() = scope.async { "thing" }
+            val inferredDeferred = scope.async { "thing" }
+            fun immediate(): String = "thing"
+            val immediate: String = "thing"
+
+            fun awaitLocally() {
+                fun localDeferred(): Deferred<String> = scope.async { "thing" }
+                localDeferred()
+            }
+        }
+        """
+        val findings = NoDeferredResultInPublicApi(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
 }

--- a/src/test/kotlin/me/haroldmartin/detektrules/NoNotNullOperatorTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/NoNotNullOperatorTest.kt
@@ -29,4 +29,14 @@ internal class NoNotNullOperatorTest(private val env: KotlinCoreEnvironment) {
         val findings = NoNotNullOperator(Config.empty).compileAndLintWithContext(env, code)
         findings shouldHaveSize 0
     }
+
+    @Test
+    fun `does not report other postfix operators`() {
+        val code = """
+        var count = 0
+        count++
+        """
+        val findings = NoNotNullOperator(Config.empty).compileAndLintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
 }

--- a/src/test/kotlin/me/haroldmartin/detektrules/NoRunBlockingTest.kt
+++ b/src/test/kotlin/me/haroldmartin/detektrules/NoRunBlockingTest.kt
@@ -35,4 +35,13 @@ internal class NoRunBlockingTest {
         val findings = NoRunBlocking(Config.empty).compileAndLint(code)
         findings shouldHaveSize 0
     }
+
+    @Test
+    fun `does not report invoking a lambda expression`() {
+        val code = """
+        val answer = ({ 42 })()
+        """
+        val findings = NoRunBlocking(Config.empty).compileAndLint(code)
+        findings shouldHaveSize 0
+    }
 }


### PR DESCRIPTION
…in NoLateinitVar.kt

Refactored nullable type resolution to avoid the safe-call chain in NoDeferredResultInPublicApi.kt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/hbmartin-detekt-rules/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

